### PR TITLE
Extract helperText from props

### DIFF
--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -13,6 +13,7 @@ export function fieldToTextField({
   field: { onBlur: fieldOnBlur, ...field },
   form: { isSubmitting, touched, errors },
   onBlur,
+  helperText,
   ...props
 }: TextFieldProps): MuiTextFieldProps {
   const fieldError = getIn(errors, field.name);
@@ -21,7 +22,7 @@ export function fieldToTextField({
   return {
     variant: props.variant,
     error: showError,
-    helperText: showError ? fieldError : props.helperText,
+    helperText: showError ? fieldError : helperText,
     disabled: disabled ?? isSubmitting,
     onBlur:
       onBlur ??


### PR DESCRIPTION
Fixes an issue where you supply the helperText as a prop - for example a " " to enforce the space. As it wasn't being extracted from props, the original value would always be written instead of the fieldError on error.